### PR TITLE
fixed crafty text bug on victory screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
-
-
 # The Legend of Ronald: Twilight Burger
 2D HTML5 Canvas game where Ronald McDonald and the Burger King force each other to eat their burgers.
 
 ### [Play Twilight Burger here on Heroku](https://twilightburger.herokuapp.com/)
-#### Username: test@test.com
-#### Password: Password1
 
 ## Screenshot
 ![Screenshot](./public/assets/img/gif/twilightBurger.gif)
@@ -18,12 +14,11 @@ We have done multiple "eat the burger" web apps academically, and decided to gam
 * JavaScript
 * Node and Express server
 * MongoDB
-* React JS
+* ReactJS
 * D3
 * Piskelapp Sprite sheets
 * TexturePacker Atlas sheets
 * Sound assets created using Audacity or acquired from freesound.org
-* Stormpath Authentication
 
 ## Built with
 * Atom and Sublime

--- a/app/js/game.js
+++ b/app/js/game.js
@@ -186,21 +186,18 @@ Crafty.scene('VictoryRonald', function() {
   Crafty.audio.play("ronaldLaugh",1,1);
 	// draw a new game grid with a  black background and ronald gif
   Crafty.background('#000000 url(/assets/img/gif/ronald_down_throw.gif) no-repeat center center');
-	// Game Over Text
 	Crafty.e('2D, DOM, Text')
-		.text('Player 1 Wins!')
 		.attr({
 			x: 0,
 			y: exports.Game.height()/3,
 			w: exports.Game.width(),
 			h: 100
 		})
-		.css({
-			"text-align": "center",
-			"color": "#ffffff",
-			"weight": "bold"
-		})
+		.text('Player 1 Wins!')
+		.textAlign('center')
+		.textColor("#ffffff")
 		.textFont({
+			weight: "bold",
 			size: "40px",
 			family: 'Press Start 2P'
 		});
@@ -230,24 +227,21 @@ Crafty.scene('VictoryKing', function() {
 	Crafty.background('#000000 url(/assets/img/gif/king_down_walk.gif) no-repeat center center');
 	// Game Over Text
 	Crafty.e('2D, DOM, Text')
-		.text('Player 2 Wins!')
 		.attr({
 			x: 0,
 			y: exports.Game.height()/3,
 			w: exports.Game.width(),
 			h: 100
 		})
-		.css({
-			"text-align": "center",
-			"color": "#ffffff",
-			"weight": "bold"
-		})
+		.text('Player 2 Wins!')
+		.textAlign('center')
+		.textColor("#ffffff")
 		.textFont({
+			weight: "bold",
 			size: "40px",
 			family: 'Press Start 2P'
 		});
 
-  // Crafty.background('url(http://i49.tinypic.com/egd83n.jpg)');
   this.restart_game = this.bind('KeyDown', function(e) {
   	if (e.key == Crafty.keys["ENTER"]) {
   		Crafty.scene('Main');


### PR DESCRIPTION
After crafty update, the victory text was no longer centered in the game grid.  crafty introduced a new ``` .textAlign()``` function to control positioning and a ``` .textColor()``` to handle those css properties, even though you can still use ``` .css() ``` to set normal css properties.  you just can't use ```.css()``` to set the color or alignment anymore.  